### PR TITLE
Fix `initial.dir` when `type='selectdir'`

### DIFF
--- a/R/gfile.R
+++ b/R/gfile.R
@@ -81,6 +81,8 @@ NULL
     if(!is.null(initial.filename))
       filechooser$SetFilename(initial.filename)
     filechooser$setCurrentFolder(initial.dir)
+  } else if(type == "selectdir") {
+      filechooser$setCurrentFolder(initial.dir)
   }
   
   ## this makes it modal

--- a/R/gfile.R
+++ b/R/gfile.R
@@ -67,23 +67,23 @@ NULL
       filechooser$AddFilter(filefilter)
     }
   }
+  
+  ## this works *exactly* the same as the previous ifelseifelseifelse
+  #switch(type,
+  #       "open" = ,
+  #       "save" = {
+  #         if(!is.null(initial.filename))
+  #           filechooser$SetFilename(initial.filename)
+  #         filechooser$setCurrentFolder(initial.dir)
+  #       },
+  #       "selectdir" = {
+  #         filechooser$setCurrentFolder(initial.dir)
+  #       })
 
-  ## boy this could be tidied up, but is it correct?
-  if(type == "open") {
-    if(!is.null(initial.filename))
-      filechooser$SetFilename(initial.filename)
-    filechooser$setCurrentFolder(initial.dir)
-  } else if(type == "open") {
-    if(!is.null(initial.filename))
-      filechooser$SetFilename(initial.filename)
-    filechooser$setCurrentFolder(initial.dir)
-  } else if(type == "save") {
-    if(!is.null(initial.filename))
-      filechooser$SetFilename(initial.filename)
-    filechooser$setCurrentFolder(initial.dir)
-  } else if(type == "selectdir") {
-      filechooser$setCurrentFolder(initial.dir)
-  }
+  ## but I think this does the same thing??
+  if (type %in% c("open", "save") && !is.null(initial.filename))
+    filechooser$SetFilename(initial.filename)
+  filechooser$setCurrentFolder(initial.dir)
   
   ## this makes it modal
   response <- filechooser$Run()


### PR DESCRIPTION
It looks like the only difference between "open"/"save" and "selectdir" is that the former set the initial filename. I first reduced `if else` to a `switch`, which makes it obvious ... I tested it out a little and it didn't break. I left the switch in case for whatever reason you want to keep it for future flexibility ... 