### PR TITLE
revert 2d49f391 (plm fixed upstream in SVN)

### DIFF
--- a/R/gdf.R
+++ b/R/gdf.R
@@ -225,7 +225,7 @@ GDfBase <- setRefClass("GDfBase",
 
                          ## if any row is all NA, then we set the class to numeric
                          for (nm in names(items)) {
-                           if(all(is.na(items[,nm]))) {
+                           if(all(is.na(items[nm]))) {
                              items[nm] <- rep(NA_real_, nrow(items))
                            }
                          }


### PR DESCRIPTION
This workaround for plm data was initially introduced because of an obscure bug in mimicing `[.data.frame` behavior for `pdata.frame` objects. This has now been fixed upstream in plm SVN: 
https://r-forge.r-project.org/scm/viewvc.php?view=rev&root=plm&revision=255

And hopefully there'll be a new release of `plm` soon.

I think it's a good idea to revert to previous behavior in `gWidgets2RGtk2` to avoid any unintentional issues creeping in...