### PR TITLE
Fixes issue when gdf has one row

### DIFF
--- a/R/gdf.R
+++ b/R/gdf.R
@@ -295,7 +295,7 @@ GDfBase <- setRefClass("GDfBase",
                          "Get data frame from columns. Skips deleted rows, but returns non-visible ones"
                          columns <- widget$getColumns()[-1] # drop rownames
                          cols <- sapply(columns, function(vc) vc$getData("n"))
-                         out <- model[]
+                         out <- as.data.frame(model)
                          ## must convert character to Date before subsetting.
                          inds <- which(sapply(out, function(x) is(x, "mylogical")))
                          for (i in inds) 

--- a/R/gtable.R
+++ b/R/gtable.R
@@ -45,7 +45,7 @@ make_treeview_column.default <- function(x, col_no, self) {
 ##  event_box$addEvents('all-events-mask')
   event_box$add(label)
   event_box$setAboveChild(TRUE)         # gets events to box
-  
+
   view_col$setWidget(event_box)
   view_col
 }
@@ -74,7 +74,7 @@ make_treeview_column.Date <- function(x, col_no, self) {
 ##  event_box$addEvents('all-events-mask')
   event_box$add(label)
   event_box$setAboveChild(TRUE)         # gets events to box
-  
+
   view_col$setWidget(event_box)
   view_col
 }
@@ -105,17 +105,17 @@ GTable <- setRefClass("GTable",
                                 handler = NULL, action = NULL,
                                 container = NULL, ... ) {
 
-                                
+
                                 widget <<- gtkTreeViewNew()
-                                
+
                                 block <<- gtkScrolledWindowNew()
                                 block$setPolicy("GTK_POLICY_AUTOMATIC","GTK_POLICY_AUTOMATIC")
                                 block$add(widget)
-                                
+
                                 if(multiple)
                                   set_selection_mode("multiple")
-                              
-                                
+
+
                                 if(missing(items) || length(items) > 1)
                                   widget$SetRulesHint(TRUE)
                                 widget$SetEnableSearch(TRUE)
@@ -126,7 +126,7 @@ GTable <- setRefClass("GTable",
                                   icon.col <- match(icon.col, names(items))
                                 if(is.numeric(icon.col))
                                   icon.col <- as.integer(icon.col)
-                                
+
                                 if(is.character(tooltip.col))
                                   tooltip.col <- as.integer(match(tooltip.col, names(items)))
                                 if(is.numeric(tooltip.col))
@@ -143,7 +143,7 @@ GTable <- setRefClass("GTable",
 
 
                                 set_items(items)
-                                
+
                                 add_to_parent(container, .self, ...)
 
                                 ## hack in click events here
@@ -164,7 +164,7 @@ GTable <- setRefClass("GTable",
                                 }
                                 connect_to_toolkit_signal("button-press-event", click_decorator)
 
-                                
+
                                 handler_id <<- add_handler_changed(handler, action)
 
                                 callSuper(toolkit)
@@ -239,13 +239,13 @@ GTable <- setRefClass("GTable",
                         find_col_no = function(view.col) {
                           ind <- which(sapply(widget$getColumns(), function(i) identical(i, view.col)))
                           ind - !is.null(icon_col)
-                        },                        
+                        },
                         add_popup=function(menu_fun=NULL) {
                           "Add a popup menu to the columns. Function should generate list of actions, ..."
                           if(is.null(menu_fun))
                             menu_fun <- .self$default_popup_menu
-                          
-                          
+
+
                           sapply(get_view_columns(), function(view.col) {
                             view.col$setClickable(TRUE)
                             col_no <- find_col_no(view.col)
@@ -267,7 +267,7 @@ GTable <- setRefClass("GTable",
                         },
                         remove_popup_menu=function() {
                           "remove popup menu from column headers"
-                          
+
                           sapply(get_view_columns(), function(view.col) {
                             view.col$setClickable(FALSE)
                             btn <- view.col$getWidget()$getParent()$getParent()$getParent()
@@ -301,7 +301,7 @@ GTable <- setRefClass("GTable",
                           if(!is.null(icon_col))
                             columns <- columns[-1]
                           columns
-                        }, 
+                        },
                         get_selected=function() {
                           "Get selected indices or numeric(0)"
                           sel_model <- widget$getSelection()
@@ -309,7 +309,7 @@ GTable <- setRefClass("GTable",
                           if(is.null(x))
                             return(integer(0))
                           x <- as.numeric(x) + 1L # hide, deleted
-                          
+
                           x
                         },
                         set_selected=function(ind) {
@@ -318,7 +318,7 @@ GTable <- setRefClass("GTable",
                           sel_model = widget$getSelection()
                           block_handlers()
                           sel_model$unselectAll()
-                       
+
                           lapply(ind, function(i) sel_model$selectPath(gtkTreePathNewFromString(i)))
                           unblock_handlers()
                           if ((length(ind) != length(old_ind)) ||
@@ -341,7 +341,7 @@ GTable <- setRefClass("GTable",
                           idx <- get_selected()
                           idx <- which(get_visible())[idx]
 
-                          
+
                           vals <- get_items(drop=FALSE)[idx, , drop=FALSE]
                           if(getWithDefault(drop, TRUE))
                             vals[, chosen_col, drop=TRUE]
@@ -360,7 +360,7 @@ GTable <- setRefClass("GTable",
                           if(length(ind) == 0)
                             return() ## no match
                           set_index(ind)
-                          unblock_handlers()                          
+                          unblock_handlers()
                         },
                         get_index = function(...) {
                           "Get index of selected rows or integer(0)"
@@ -369,7 +369,7 @@ GTable <- setRefClass("GTable",
                         },
                         set_index = function(value,...) {
                           "set selected values in value. integer(0) or 0L clears selection"
-                          if(length(value) == 0 || value < 1)
+                          if(length(value) == 0 || (length(value) == 1L && value < 1))
                             widget$getSelection()$unselectAll() # clear selection if not >= 1
                           else {
                             ## selected wants actual for filtered
@@ -382,7 +382,7 @@ GTable <- setRefClass("GTable",
                           DF <- get_model()[]
                           if(!is.data.frame(DF) && is.list(DF))
                             DF <- as.data.frame(DF, stringsAsFactors=FALSE)
-                          
+
                           DF <- DF[, get_valid_columns(), drop=FALSE]
                           names(DF) <- get_names()
                           ## we possibly drop out some stuff
@@ -401,7 +401,7 @@ GTable <- setRefClass("GTable",
                                 value <- data.frame(value, stringsAsFactors=FALSE)
                             }
                             ## icons
-                            if(!is.null(icon_col)) 
+                            if(!is.null(icon_col))
                               value[[icon_col]] <-  getStockIconByName(value[[icon_col]])
                             ## visible column
                             items <<- cbind(value, ..visible=rep(TRUE, nrow(value)))
@@ -443,7 +443,7 @@ GTable <- setRefClass("GTable",
                           m <- get_dim()[2]
                           if(length(value) != m)
                             return()
-                         
+
                           f <- function(col, nm) {
                             label <- col$getWidget()$getChild()
                             label$setLabel(nm)
@@ -514,4 +514,3 @@ GTable <- setRefClass("GTable",
                         }
 
                         ))
-


### PR DESCRIPTION
Hi,

The following example uncovers a bug in `get_frame()` when there's only a single row:
```r
w <- gwindow()
g <- ggroup(container = w)

df <- gdf(data.frame(x = 1:2), container = g)
df2 <- gdf(data.frame(x = 1), container = g)

df$get_frame()
df2$get_frame() 
# Error in out[not_deleted(), cols, drop = FALSE] : 
#   incorrect number of dimensions
```
It seems that `[]` returns a data.frame *unless* there's only one row, in which case it returns a list.

I do not claim any understanding of the differences in behaviour of `[]` and `as.data.frame()`, but in my example, the latter resolves the problem.

Take care,
Tom.